### PR TITLE
Maclockard/order package

### DIFF
--- a/monorepo.lint.ts
+++ b/monorepo.lint.ts
@@ -63,6 +63,33 @@ module.exports = {
           "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
       },
       exclude: ["monorepo-lint"]
+    },
+    {
+      type: "@monorepo-lint/expect-package-order",
+      args: {
+        order: [
+          "name",
+          "version",
+          "author",
+          "url",
+          "license",
+          "private",
+          "main",
+          "typings",
+          "style",
+          "sideEffects",
+          "workspaces",
+          "husky",
+          "lint-staged",
+          "scripts",
+          "dependencies",
+          "peerDependencies",
+          "devDependencies",
+          "publishConfig",
+          "gitHead"
+        ]
+      },
+      exclude: [],
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
   "private": true,
-  "scripts": {
-    "build": "cd packages/all; tsc --build",
-    "build:watch": "cd packages/all; tsc --build --watch",
-    "prettier:all": "prettier 'packages/*/src/**/*.{ts,tsx,less}' --write",
-    "prettier:check": "prettier 'packages/*/src/**/*.{ts,tsx,less}' -l",
-    "test": "lerna run test"
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
   },
   "husky": {
     "hooks": {
@@ -23,10 +21,12 @@
       "git add"
     ]
   },
-  "workspaces": {
-    "packages": [
-      "packages/*"
-    ]
+  "scripts": {
+    "build": "cd packages/all; tsc --build",
+    "build:watch": "cd packages/all; tsc --build --watch",
+    "prettier:all": "prettier 'packages/*/src/**/*.{ts,tsx,less}' --write",
+    "prettier:check": "prettier 'packages/*/src/**/*.{ts,tsx,less}' -l",
+    "test": "lerna run test"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -8,6 +8,7 @@
     "@monorepo-lint/expect-file-contents": "^0.1.6",
     "@monorepo-lint/expect-package-script": "^0.1.6",
     "@monorepo-lint/expect-standard-tsconfig": "^0.1.6",
+    "@monorepo-lint/expect-package-order": "^0.1.6",
     "@monorepo-lint/utils": "^0.1.6"
   },
   "scripts": {

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -2,6 +2,13 @@
   "name": "@monorepo-lint/all",
   "version": "0.1.6",
   "license": "MIT",
+  "scripts": {
+    "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
+    "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
+    "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
+    "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
+    "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
   "dependencies": {
     "@monorepo-lint/cli": "^0.1.6",
     "@monorepo-lint/core": "^0.1.6",
@@ -10,13 +17,6 @@
     "@monorepo-lint/expect-standard-tsconfig": "^0.1.6",
     "@monorepo-lint/expect-package-order": "^0.1.6",
     "@monorepo-lint/utils": "^0.1.6"
-  },
-  "scripts": {
-    "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
-    "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
-    "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
-    "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
-    "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/all/tsconfig.json
+++ b/packages/all/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../expect-standard-tsconfig"
     },
     {
+      "path": "../expect-package-order"
+    },
+    {
       "path": "../utils"
     }
   ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@monorepo-lint/cli",
-  "version": "0.1.6",
-  "main": "build/index.js",
-  "typings": "build/index.d.ts",
-  "license": "MIT",
   "bin": {
     "monorepo-lint": "./bin/monorepo-lint"
   },
-  "devDependencies": {
-    "@types/yargs": "^12.0.1"
-  },
-  "dependencies": {
-    "@monorepo-lint/utils": "^0.1.6",
-    "yargs": "^12.0.5"
-  },
+  "name": "@monorepo-lint/cli",
+  "version": "0.1.6",
+  "license": "MIT",
+  "main": "build/index.js",
+  "typings": "build/index.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
     "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
     "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
+  "dependencies": {
+    "@monorepo-lint/utils": "^0.1.6",
+    "yargs": "^12.0.5"
+  },
+  "devDependencies": {
+    "@types/yargs": "^12.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@monorepo-lint/core",
   "version": "0.1.6",
-  "main": "build/index.js",
   "author": "Eric Anderson",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
-  "typings": "build/index.d.ts",
   "license": "MIT",
+  "main": "build/index.js",
+  "typings": "build/index.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",

--- a/packages/expect-file-contents/package.json
+++ b/packages/expect-file-contents/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@monorepo-lint/expect-file-contents",
   "version": "0.1.6",
-  "main": "build/expectFileContents.js",
-  "typings": "build/expectFileContents.d.ts",
   "author": "Eric Anderson",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
-  "dependencies": {
-    "jest-diff": "^23.6.0"
-  },
-  "devDependencies": {
-    "@types/jest-diff": "^20.0.0"
-  },
+  "main": "build/expectFileContents.js",
+  "typings": "build/expectFileContents.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
     "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
     "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
+  "dependencies": {
+    "jest-diff": "^23.6.0"
+  },
+  "devDependencies": {
+    "@types/jest-diff": "^20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect-package-order/jest.config.js
+++ b/packages/expect-package-order/jest.config.js
@@ -1,0 +1,162 @@
+// STOP!
+// WAIT!
+// Unless this is the version inside of "templates", you are editing a generated file. 
+module.exports = {
+  clearMocks: true,
+  coverageDirectory: "coverage",
+
+  coveragePathIgnorePatterns: [
+    "/node_modules/"
+  ],
+
+  coverageReporters: [
+    "json",
+    "text",
+    "lcov",
+    "clover"
+  ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: null,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files usin a array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: null,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: null,
+
+  // A set of global variables that need to be available in all test environments
+  globals: {
+    "ts-jest": {
+      "tsConfig": "./tsconfig.json"
+    }
+  },
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  moduleFileExtensions: [
+    "ts",
+    "tsx",
+    "js"
+  ],
+
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  notify: true,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "always",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: null,
+
+  // Run tests from one or more projects
+  // projects: null,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: null,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: null,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // The path to a module that runs some code to configure or set up the testing framework before each test
+  // setupTestFrameworkScriptFile: null,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: [
+    "**/__tests__/*.spec.+(ts|tsx|js)"
+  ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/build"
+  ],
+
+  // The regexp pattern Jest uses to detect test files
+  // testRegex: "",
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: null,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  },
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  verbose: true,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/packages/expect-package-order/package.json
+++ b/packages/expect-package-order/package.json
@@ -1,19 +1,21 @@
 {
   "name": "@monorepo-lint/expect-package-order",
   "version": "0.1.6",
-  "main": "build/expectPackageOrder.js",
-  "typings": "build/expectPackageOrder.d.ts",
   "author": "Mac Lockard",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
+  "main": "build/expectPackageOrder.js",
+  "typings": "build/expectPackageOrder.d.ts",
+  "scripts": {
+    "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
+    "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
+    "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
   "dependencies": {
     "jest-diff": "^23.6.0"
   },
   "devDependencies": {
     "@types/jest-diff": "^20.0.0"
-  },
-  "scripts": {
-    "lint": "tslint --config ../../tslint.json --project ."
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect-package-order/package.json
+++ b/packages/expect-package-order/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@monorepo-lint/expect-package-order",
+  "version": "0.1.6",
+  "main": "build/expectPackageOrder.js",
+  "typings": "build/expectPackageOrder.d.ts",
+  "author": "Mac Lockard",
+  "url": "https://github.com/monorepo-lint/monorepo-lint",
+  "license": "MIT",
+  "dependencies": {
+    "jest-diff": "^23.6.0"
+  },
+  "devDependencies": {
+    "@types/jest-diff": "^20.0.0"
+  },
+  "scripts": {
+    "lint": "tslint --config ../../tslint.json --project ."
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "33f740167f2d7cc4f4ddf85a64addc8a73de0dcd"
+}

--- a/packages/expect-package-order/src/expectPackageOrder.ts
+++ b/packages/expect-package-order/src/expectPackageOrder.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright (c) 2018 Eric L Anderson (http://monorepo-lint.com). All Right Reserved.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ *
+ */
+
+import { Context } from "@monorepo-lint/core";
+import { writeJson } from "@monorepo-lint/utils";
+import diff from "jest-diff";
+
+export interface Opts {
+  readonly order: ReadonlyArray<string> | OrderFunction;
+}
+
+export type OrderFunction = ((
+  context: Context
+) => (a: string, b: string) => number);
+
+export default function expectPackageOrder(context: Context, opts: Opts) {
+  const packageJson = context.getPackageJson();
+  const packagePath = context.getPackageJsonPath();
+
+  const { order } = opts;
+
+  const compartor = isOrderFunction(order)
+    ? order(context)
+    : createCompartor(order);
+
+  const actualOrder = Object.keys(packageJson);
+  const expectedOrder = actualOrder.slice().sort(compartor); // sort mutates, so we need to copy the previous result
+
+  if (!arrayOrderCompare(actualOrder, expectedOrder)) {
+    const expectedPackageJson: Record<string, any> = {};
+
+    expectedOrder.forEach(key => {
+      expectedPackageJson[key] = packageJson[key];
+    });
+
+    context.addError({
+      file: packagePath,
+      message: "Incorrect order of fields in package.json",
+      longMessage: diff(expectedOrder, actualOrder, { expand: true }),
+      fixer: () => {
+        writeJson(packagePath, expectedPackageJson);
+      }
+    });
+  }
+}
+
+function arrayOrderCompare(a: ReadonlyArray<string>, b: ReadonlyArray<string>) {
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function createCompartor(order: ReadonlyArray<string>) {
+  // tslint:disable-next-line:only-arrow-functions
+  return function(a: string, b: string) {
+    return order.indexOf(a) - order.indexOf(b);
+  };
+}
+
+function isOrderFunction(
+  order: ReadonlyArray<string> | OrderFunction
+): order is OrderFunction {
+  return !Array.isArray(order);
+}

--- a/packages/expect-package-order/tsconfig.json
+++ b/packages/expect-package-order/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": [
+      "es2015"
+    ],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "composite": true,
+    "importHelpers": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "references": []
+}

--- a/packages/expect-package-script/package.json
+++ b/packages/expect-package-script/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@monorepo-lint/expect-package-script",
   "version": "0.1.6",
-  "main": "build/expectPackageScript.js",
-  "typings": "build/expectPackageScript.d.ts",
   "author": "Eric Anderson",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
-  "dependencies": {
-    "jest-diff": "^23.6.0"
-  },
-  "devDependencies": {
-    "@types/jest-diff": "^20.0.0"
-  },
+  "main": "build/expectPackageScript.js",
+  "typings": "build/expectPackageScript.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
     "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
     "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
+  "dependencies": {
+    "jest-diff": "^23.6.0"
+  },
+  "devDependencies": {
+    "@types/jest-diff": "^20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect-standard-tsconfig/package.json
+++ b/packages/expect-standard-tsconfig/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@monorepo-lint/expect-standard-tsconfig",
   "version": "0.1.6",
-  "main": "build/expectStandardTsconfig.js",
-  "typings": "build/expectStandardTsconfig.d.ts",
   "author": "Eric Anderson",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
-  "dependencies": {
-    "jest-diff": "^23.6.0"
-  },
-  "devDependencies": {
-    "@types/jest-diff": "^20.0.0"
-  },
+  "main": "build/expectStandardTsconfig.js",
+  "typings": "build/expectStandardTsconfig.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
     "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
     "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
+  "dependencies": {
+    "jest-diff": "^23.6.0"
+  },
+  "devDependencies": {
+    "@types/jest-diff": "^20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@monorepo-lint/utils",
   "version": "0.1.6",
-  "main": "build/index.js",
-  "typings": "build/index.d.ts",
   "author": "Eric Anderson",
   "url": "https://github.com/monorepo-lint/monorepo-lint",
   "license": "MIT",
-  "dependencies": {
-    "glob": "^7.1.3"
-  },
-  "devDependencies": {
-    "@types/glob": "^7.1.1"
-  },
+  "main": "build/index.js",
+  "typings": "build/index.d.ts",
   "scripts": {
     "lint": "../../node_modules/.bin/tslint --config ../../tslint.json --project .",
     "jest": "../../node_modules/.bin/jest --config ../../jest.config.js",
     "jest:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --watch",
     "test": "../../node_modules/.bin/jest --config ../../jest.config.js --colors",
     "test:watch": "../../node_modules/.bin/jest --config ../../jest.config.js --colors --watch"
+  },
+  "dependencies": {
+    "glob": "^7.1.3"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/src/PackageJson.ts
+++ b/packages/utils/src/PackageJson.ts
@@ -15,4 +15,5 @@ export interface PackageJson {
         nohoist?: string[];
       }
     | string[];
+  [otherKey: string]: any;
 }


### PR DESCRIPTION
This PR adds a check for enforcing a standard order for `package.json` fields. Can take either an array or a function for doing doing the comparison.